### PR TITLE
[PSUd]Update predefined position_in_parent and parent_name of PSU onl…

### DIFF
--- a/sonic-psud/scripts/psud
+++ b/sonic-psud/scripts/psud
@@ -412,6 +412,9 @@ class DaemonPsud(daemon_base.DaemonBase):
         fvs = swsscommon.FieldValuePairs([(CHASSIS_INFO_PSU_NUM_FIELD, str(self.num_psus))])
         self.chassis_tbl.set(CHASSIS_INFO_KEY, fvs)
 
+        # Update predefined position_in_parent and parent_name for PSU
+        self._update_psu_entity_info()
+
     def __del__(self):
         # Delete all the information from DB and then exit
         for psu_index in range(1, self.num_psus + 1):
@@ -442,7 +445,6 @@ class DaemonPsud(daemon_base.DaemonBase):
             # We received a fatal signal
             return False
 
-        self._update_psu_entity_info()
         psu_db_update(self.psu_tbl, self.num_psus)
         self.update_psu_data()
         self._update_led_color()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
The values of position_in_parent and parent_name for PSU will remain unchanged. Consequently, update the predefined position_in_parent and parent_name of the PSU only once.
#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

Since the values of position_in_parent and parent_name of the PSU do not change, these fields only need to be updated once.
#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Booting on a SONiC switch, and check the STATE DB ""PHYSICAL_ENTITY_INFO|PSU *" table "position_in_parent" field and "parent_name" field.
#### Additional Information (Optional)
https://github.com/sonic-net/sonic-platform-daemons/pull/452