### PR TITLE
xcvrd exception when change port speed for RJ45 ports

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -2202,16 +2202,12 @@ class SfpStateUpdateTask(threading.Thread):
             transceiver_dict = {}
             # transceiver_dom_dict = {}
 
-            port_info_dict = _wrapper_get_transceiver_info(pport)
-            if port_info_dict is not None:
-                transceiver_dict[pport] = port_info_dict
+            if _wrapper_get_presence(pport):
+                port_info_dict = _wrapper_get_transceiver_info(pport)
+                if port_info_dict is not None:
+                    transceiver_dict[pport] = port_info_dict
 
-            # dom_info_dict = _wrapper_get_transceiver_dom_info(pport)
-            # if dom_info_dict is not None:
-            #     beautify_dom_info_dict(dom_info_dict, pport)
-            #     transceiver_dom_dict[pport] = dom_info_dict
-
-            media_settings_parser.notify_media_setting(lport, transceiver_dict, self.xcvr_table_helper.get_app_port_tbl(port_change_event.asic_id), self.xcvr_table_helper.get_cfg_port_tbl(port_change_event.asic_id), self.port_mapping, self.port_dict)
+                media_settings_parser.notify_media_setting(lport, transceiver_dict, self.xcvr_table_helper.get_app_port_tbl(port_change_event.asic_id), self.xcvr_table_helper.get_cfg_port_tbl(port_change_event.asic_id), self.port_mapping, self.port_dict)
 
     def on_remove_logical_port(self, port_change_event):
         """Called when a logical port is removed from CONFIG_DB.


### PR DESCRIPTION
Root Cause:
  exception log:
```
    ERR pmon#xcvrd:   File "/usr/local/lib/python3.9/dist-packages/sonic_platform_base/sonic_xcvr/sfp_optoe_base.py", line 244, in read_eeprom
    ERR pmon#xcvrd:     with open(self.get_eeprom_path(), mode='rb', buffering=0) as f:
    ERR pmon#xcvrd:   File "/usr/local/lib/python3.9/dist-packages/sonic_platform/sfp.py", line 80, in get_eeprom_path
    ERR pmon#xcvrd:     return self.port_to_eeprom_mapping[self.port_num]
    ERR pmon#xcvrd: KeyError: 1
```
  There is no eeprom for RJ45.

Solution:
  There is no need for a pre-emphasis setting if a transceiver is not inserted.
  It always returns false from "get_presence" for RJ45.
  Added a check to see if a transceiver is presented before applying the media setting.

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
