### PR TITLE
skip CMIS init if config state is ConfigUndefined

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1024,10 +1024,10 @@ class CmisManagerTask(threading.Thread):
                 if dp_state[name] != 'DataPathActivated':
                     skip = False
                     break
-                #name = "ConfigStatusLane{}".format(lane + 1)
-                #if conf_state[name] != 'ConfigSuccess':
-                #    skip = False
-                #    break
+                name = "ConfigStatusLane{}".format(lane + 1)
+                if conf_state[name] != 'ConfigSuccess' and conf_state[name] != 'ConfigUndefined':
+                    skip = False
+                    break
             return (not skip)
         return True
 


### PR DESCRIPTION
For the ET8001-2FR4, if there are two breakout ports, the config status for one would be ConfigSuccess and the other would be ConfigUndefined.

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
