### PR TITLE
Update xcvrd.py to avoid casting error

### DIFF
--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -996,7 +996,7 @@ class CmisManagerTask:
             if 'admin_status' in port_change_event.port_dict:
                 self.port_dict[lport]['admin_status'] = port_change_event.port_dict['admin_status']
             if 'laser_freq' in port_change_event.port_dict:
-                self.port_dict[lport]['laser_freq'] = int(port_change_event.port_dict['laser_freq'])
+                self.port_dict[lport]['laser_freq'] = int(float(port_change_event.port_dict['laser_freq']))
             if 'tx_power' in port_change_event.port_dict:
                 self.port_dict[lport]['tx_power'] = float(port_change_event.port_dict['tx_power'])
 


### PR DESCRIPTION


<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
I first convert `port_change_event.port_dict['laser_freq']` to a float value, then to a int, to avoid this problem.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
When using the command
`sudo config interface transceiver frequency Ethernet0 195000 100` In /var/log/syslog, there is a error message says that 
```
File "/usr/local/lib/python3.9/dist-packages/xcvrd/xcvrd.py", line 2378, in run self.task_worker()
File "/usr/local/lib/python3.9/dist-packages/xcvrd/xcvrd.py", line 1900, in task_worker
port_change_observer.handle_port_update_event()
File "/usr/local/lib/python3.9/dist-packages/xcvrd/xcvrd_utilities/port_event_helper.py", line 179, in handle_port_update_event
self.port_change_event_handler(port_change_event)
File "/usr/local/lib/python3.9/dist-packages/xcvrd/xcvrd.py", line 1316, in on_port_update_event
self.port_dict[lport]['laser_freq'] = int(port_change_event.port_dict['laser_freq'])
ValueError: invalid literal for int() with base 10: '195000.0'
```
Even though we input a integer, the parser seems to use a float number.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
I edit the code in the container from docker-platform-monitor image, which is on SONiC and on AIS800-64D.

before changed:
![image](https://github.com/user-attachments/assets/9d68cedd-46f5-4018-b5fd-b80421be5434)

after changed:
![image](https://github.com/user-attachments/assets/b64e6ef3-6c5d-434d-9ea5-1174ee5cf66b)

#### Additional Information (Optional)
