### PR TITLE
Syslog for transceiver high/low temperature alarm

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -1564,6 +1564,7 @@ class TestXcvrdScript(object):
         task = DomInfoUpdateTask(DEFAULT_NAMESPACE, port_mapping, stop_event)
         task.xcvr_table_helper = XcvrTableHelper(DEFAULT_NAMESPACE)
         task.task_stopping_event.wait = MagicMock(side_effect=[False, True])
+        task.check_transceiver_temperature = MagicMock()
         mock_detect_error.return_value = True
         task.task_worker()
         assert task.port_mapping.logical_port_list.count('Ethernet0')
@@ -1579,6 +1580,47 @@ class TestXcvrdScript(object):
         assert mock_post_dom_info.call_count == 1
         assert mock_update_status_hw.call_count == 1
         assert mock_post_pm_info.call_count == 1
+
+    @patch('xcvrd.xcvrd_utilities.port_mapping.PortMapping.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
+    @patch('xcvrd.xcvrd._wrapper_get_presence', MagicMock(return_value=True))
+    @pytest.mark.parametrize("dom_info_cache, dom_th_info, expected", [
+        ({0: {'temperature': '75'}},
+         (('temphighalarm', '80'),
+          ('templowalarm', '0'),
+          ('temphighwarning', '70'),
+          ('templowwarning', '0')),
+         3), #TEMP_NORMAL = 0
+        ({0: {'temperature': '85'}},
+         (('temphighalarm', '80'),
+          ('templowalarm', '0'),
+          ('temphighwarning', '70'),
+          ('templowwarning', '10')),
+         1), #TEMP_HIGH_ALARM = 1
+        ({0: {'temperature': '5'}},
+         (('temphighalarm', '80'),
+          ('templowalarm', '0'),
+          ('temphighwarning', '70'),
+          ('templowwarning', '10')),
+         4), #TEMP_LOW_WARNING = 4
+    ])
+    def test_check_transceiver_temperature(self, dom_info_cache, dom_th_info, expected):
+        class MockTable:
+            data = {}
+            def set(self, key, fvs):
+                self.data[key] = fvs
+
+            def get(self, key):
+                return self.data.get(key)
+
+        port_mapping = PortMapping()
+        stop_event = threading.Event()
+        task = DomInfoUpdateTask(DEFAULT_NAMESPACE, port_mapping, stop_event)
+        logical_port_name = 'Ethernet0'
+        temperature_status = {}
+        dom_th_tbl = MockTable()
+        dom_th_tbl.get = MagicMock(return_value=(True, dom_th_info))
+        task.check_transceiver_temperature(logical_port_name, dom_th_tbl, dom_info_cache, temperature_status)
+        assert temperature_status[0] == expected
 
     @patch('xcvrd.xcvrd._wrapper_get_presence', MagicMock(return_value=False))
     @patch('xcvrd.xcvrd.XcvrTableHelper')

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1663,6 +1663,7 @@ class DomInfoUpdateTask(threading.Thread):
         transceiver_status_cache = {}
         pm_info_cache = {}
         sel, asic_context = port_mapping.subscribe_port_config_change(self.namespaces)
+        temperature_status = {}
 
         # Start loop to update dom info in DB periodically
         while not self.task_stopping_event.wait(DOM_INFO_UPDATE_PERIOD_SECS):
@@ -1706,6 +1707,8 @@ class DomInfoUpdateTask(threading.Thread):
                         helper_logger.log_warning("Got exception {} while processing pm info for port {}, ignored".format(repr(e), logical_port_name))
                         continue
 
+                    self.check_transceiver_temperature(logical_port_name, self.xcvr_table_helper.get_dom_threshold_tbl(asic_index), dom_info_cache, temperature_status)
+
         helper_logger.log_info("Stop DOM monitoring loop")
 
     def run(self):
@@ -1728,6 +1731,64 @@ class DomInfoUpdateTask(threading.Thread):
         threading.Thread.join(self)
         if self.exc:
             raise self.exc
+
+    def check_transceiver_temperature(self, logical_port_name, th_table, dom_info_cache, temperature_status):
+        TEMP_NORMAL = 0
+        TEMP_HIGH_ALARM = 1
+        TEMP_LOW_ALARM = 2
+        TEMP_HIGH_WARNING = 3
+        TEMP_LOW_WARNING = 4
+
+        TEMP_ERROR_TO_DESCRIPTION_DICT = {
+            TEMP_NORMAL: "normal",
+            TEMP_HIGH_ALARM: "temperature high alarm",
+            TEMP_LOW_ALARM: "temperature low alarm",
+            TEMP_HIGH_WARNING: "temperature high warning",
+            TEMP_LOW_WARNING: "temperature low warning"
+        }
+
+        for physical_port, physical_port_name in get_physical_port_name_dict(logical_port_name, self.port_mapping).items():
+            ori_temp_status = temperature_status.get(physical_port)
+            if ori_temp_status is None:
+                ori_temp_status = TEMP_NORMAL
+                temperature_status[physical_port] = ori_temp_status
+            new_temp_status = TEMP_NORMAL
+
+            dom_info_dict = dom_info_cache.get(physical_port)
+            presence, threshold = th_table.get(physical_port_name)
+            if presence:
+                dom_th_info_dict = dict(threshold)
+            else:
+                dom_th_info_dict = None
+            if dom_info_dict is not None and dom_th_info_dict is not None:
+                temperature = dom_info_dict.get("temperature")
+                temphighalarm = dom_th_info_dict.get("temphighalarm")
+                templowalarm = dom_th_info_dict.get("templowalarm")
+                temphighwarning = dom_th_info_dict.get("temphighwarning")
+                templowwarning = dom_th_info_dict.get("templowwarning")
+                if temperature != 'N/A' and temphighalarm != 'N/A' and templowalarm != 'N/A' and \
+                   temphighwarning != 'N/A' and templowwarning != 'N/A':
+                    if float(temperature) > float(temphighalarm):
+                        new_temp_status = TEMP_HIGH_ALARM
+                    elif float(temperature) > float(temphighwarning):
+                        new_temp_status = TEMP_HIGH_WARNING
+                    elif float(temperature) < float(templowalarm):
+                        new_temp_status = TEMP_LOW_ALARM
+                    elif float(temperature) < float(templowwarning):
+                        new_temp_status = TEMP_LOW_WARNING
+                    else:
+                        new_temp_status = TEMP_NORMAL
+
+                if ori_temp_status != new_temp_status:
+                    temperature_status[physical_port] = new_temp_status
+                    helper_logger.log_notice("{}: temperature status change from {} to {}".format(
+                                             physical_port_name,
+                                             TEMP_ERROR_TO_DESCRIPTION_DICT[ori_temp_status],
+                                             TEMP_ERROR_TO_DESCRIPTION_DICT[new_temp_status]))
+                elif new_temp_status > 0:
+                    helper_logger.log_notice("{}: {}".format(physical_port_name, TEMP_ERROR_TO_DESCRIPTION_DICT[new_temp_status]))
+            else:
+                temperature_status[physical_port] = TEMP_NORMAL
 
     def on_port_config_change(self, port_change_event):
         if port_change_event.event_type == port_mapping.PortChangeEvent.PORT_REMOVE:


### PR DESCRIPTION
Add syslog for high/low temperature alarm/warning(compare the temperature with threshold)

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Add syslog for high/low temperature alarm/warning(compare the temperature with threshold)

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
The ZR transceiver has a protective mechanism that shuts down the transceiver when the temperature is high.
However, the user is not aware when the ZR shuts down due to high temperature.
Add syslog for this situation.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
syslog:
```
NOTICE pmon#xcvrd: Ethernet504: temperature status change from normal to temperature high warning

NOTICE pmon#xcvrd: Ethernet504: temperature status change from temperature high warning to temperature high alarm

NOTICE pmon#xcvrd: Ethernet504: temperature status change from temperature high alarm to normal

NOTICE pmon#xcvrd: Ethernet480: temperature status change from normal to temperature high warning

NOTICE pmon#xcvrd: Ethernet488: temperature status change from normal to temperature high warning

NOTICE pmon#xcvrd: Ethernet480: temperature status change from temperature high warning to temperature high alarm

NOTICE pmon#xcvrd: Ethernet488: temperature status change from temperature high warning to normal

NOTICE pmon#xcvrd: Ethernet480: temperature status change from temperature high alarm to normal
```
#### Additional Information (Optional)
