### PR TITLE
Credo AEC 400G firmware v4.1 needs to set low power mode when change …

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -1108,6 +1108,21 @@ class TestXcvrdScript(object):
         task.xcvr_table_helper.get_cfg_port_tbl = mock_table_helper.get_cfg_port_tbl
         assert task.get_configured_tx_power_from_db('Ethernet0') == -10
 
+    @pytest.mark.parametrize("appl, host_assign, vendor, expected", [
+        (1, 0x1, 'Credo', True),
+        (2, 0x11, 'Credo', False),
+        (1, 0x1, 'Molex', False)
+    ])
+    def test_CmisManagerTask_need_lp_mode_for_dpdeinit(self, appl, host_assign, vendor, expected):
+        port_mapping = PortMapping()
+        stop_event = threading.Event()
+        task = CmisManagerTask(DEFAULT_NAMESPACE, port_mapping, stop_event)
+
+        mock_xcvr_api = MagicMock()
+        mock_xcvr_api.get_manufacturer = MagicMock(return_value=vendor)
+        mock_xcvr_api.get_host_lane_assignment_option = MagicMock(return_value=host_assign)
+        assert task.need_lp_mode_for_dpdeinit(mock_xcvr_api, appl) == expected
+
     @patch('xcvrd.xcvrd.platform_chassis')
     @patch('xcvrd.xcvrd_utilities.port_mapping.subscribe_port_update_event', MagicMock(return_value=(None, None)))
     @patch('xcvrd.xcvrd_utilities.port_mapping.handle_port_update_event', MagicMock())

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -1318,6 +1318,19 @@ class CmisManagerTask(threading.Thread):
             if key in ["PortConfigDone", "PortInitDone"]:
                 break
 
+    def need_lp_mode_for_dpdeinit(self, api, appl):
+        try:
+            host_assign = api.get_host_lane_assignment_option(appl)
+            vendor = api.get_manufacturer().strip()
+        except NotImplementedError:
+            helper_logger.log_error("Required feature is not implemented")
+            return False
+
+        if vendor == "Credo" and host_assign == 0x1:
+            return True
+        else:
+            return False
+
     def task_worker(self):
         self.xcvr_table_helper = XcvrTableHelper(self.namespaces)
 
@@ -1514,7 +1527,20 @@ class CmisManagerTask(threading.Thread):
                             continue
                         self.log_notice("{}: force Datapath reinit".format(lport))
                         self.port_dict[lport]['cmis_state'] = self.CMIS_STATE_DP_DEINIT
+                        if self.need_lp_mode_for_dpdeinit(api, appl):
+                            api.set_lpmode(True)
+                            now = datetime.datetime.now()
+                            modulePwrDownDuration = self.get_cmis_module_power_down_duration_secs(api)
+                            self.log_notice("{}: ModulePwrDown duration {} secs".format(lport, modulePwrDownDuration))
+                            self.port_dict[lport]['cmis_expired'] = now + datetime.timedelta(seconds=modulePwrDownDuration)
+
                     elif state == self.CMIS_STATE_DP_DEINIT:
+                        if self.need_lp_mode_for_dpdeinit(api, appl):
+                            if not self.check_module_state(api, ['ModuleLowPwr']):
+                                if (expired is not None) and (expired <= now):
+                                    self.log_notice("{}: timeout for 'ModuleLowPwr'".format(lport))
+                                    self.force_cmis_reinit(lport, retries + 1)
+                                continue
                         # D.2.2 Software Deinitialization
                         api.set_datapath_deinit(host_lanes_mask)
 


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->
Credo AEC 400G needs to set low power mode when changing to DPDeinit state on firmware v4.1. After #254 is merged, low power mode will not be set when changing to DPDeinit state.

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->
This patch adds the code to set low power mode only when changing to DPDeinit state when the transceiver's vendor is 'Credo' and 'host_assign' is '1'(Which means the application mode only has 1 logical port on the transceiver). With this patch, the Credo AEC 400G can work correctly.

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->
Insert AEC 400G on AS9716 and verify the cable is link up.
#### Additional Information (Optional)
