### PR TITLE
Save is_warm_boot as global value for multi threads

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -506,6 +506,7 @@ class TestXcvrdScript(object):
 
     @patch('xcvrd.xcvrd_utilities.port_mapping.PortMapping.logical_port_name_to_physical_port_list', MagicMock(return_value=[0]))
     @patch('xcvrd.xcvrd.platform_sfputil', MagicMock(return_value=[0]))
+    @patch('xcvrd.xcvrd.is_warm_start', MagicMock(return_value=False))
     @patch('xcvrd.xcvrd._wrapper_get_presence', MagicMock(return_value=True))
     @patch('xcvrd.xcvrd._wrapper_is_replaceable', MagicMock(return_value=True))
     @patch('xcvrd.xcvrd.XcvrTableHelper', MagicMock())

--- a/sonic-xcvrd/xcvrd/xcvrd.py
+++ b/sonic-xcvrd/xcvrd/xcvrd.py
@@ -98,6 +98,8 @@ g_dict = {}
 platform_sfputil = None
 # Global chassis object based on new platform api
 platform_chassis = None
+# Global value to check if warm start
+is_warm_start = False
 
 # Global logger instance for helper functions and classes
 # TODO: Refactor so that we only need the logger inherited
@@ -1346,8 +1348,6 @@ class CmisManagerTask(threading.Thread):
                 break
 
     def wait_for_warm_reboot_done(self):
-        is_warm_start = is_warm_reboot_enabled()
-
         if is_warm_start:
             self.log_notice("Delay CMISManager until warmboot done")
             swsscommon.RestartWaiter.waitWarmBootDone()
@@ -1964,8 +1964,6 @@ class SfpStateUpdateTask(threading.Thread):
         transceiver_dict = {}
         retry_eeprom_set = set()
         port_dict = get_port_speed_and_lane_config()
-
-        is_warm_start = is_warm_reboot_enabled()
 
         # Post all the current interface sfp/dom threshold info to STATE_DB
         logical_port_list = port_mapping.logical_port_list
@@ -2595,6 +2593,7 @@ class DaemonXcvrd(daemon_base.DaemonBase):
     def init(self):
         global platform_sfputil
         global platform_chassis
+        global is_warm_start
 
         self.log_notice("XCVRD INIT: Start daemon init...")
 
@@ -2636,6 +2635,8 @@ class DaemonXcvrd(daemon_base.DaemonBase):
         else:
             media_settings_parser.load_media_settings()
             optics_si_parser.load_optics_si_settings()
+
+        is_warm_start = is_warm_reboot_enabled()
 
         # Make sure this daemon started after all port configured
         self.log_notice("XCVRD INIT: Wait for port config is done")


### PR DESCRIPTION
Fix error log
RuntimeError: RedisError: Failed to redisGetReply with *3\r\n$4\r\nHGET\r\n$30\r\nWARM_RESTART_ENABLE_TABLE|pmon\r\n$6\r\nenable\r\n, err=0: errstr=

When two threads send Redis commands simultaneously on one shared connection, their request/reply streams can interleave or corrupt.

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
