### PR TITLE
✅ test: Add missing mock for subscribe_port_speed_change_event in Sfp…

### DIFF
--- a/sonic-xcvrd/tests/test_xcvrd.py
+++ b/sonic-xcvrd/tests/test_xcvrd.py
@@ -1688,6 +1688,7 @@ class TestXcvrdScript(object):
         assert not task.port_mapping.logical_to_asic
         assert mock_update_status_hw.call_count == 1
 
+    @patch('xcvrd.xcvrd_utilities.port_mapping.subscribe_port_speed_change_event', MagicMock(return_value=(None, None)))
     @patch('xcvrd.xcvrd_utilities.port_mapping.subscribe_port_config_change', MagicMock(return_value=(None, None)))
     def test_SfpStateUpdateTask_task_run_stop(self):
         port_mapping = PortMapping()


### PR DESCRIPTION
…StateUpdateTask test

The test_SfpStateUpdateTask_task_run_stop test lacks a mock for subscribe_port_speed_change_event, which can cause test failures when the function attempts to subscribe to actual port speed change events. This aligns with the existing mock for subscribe_port_config_change.

<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!--
     Describe your changes in detail
-->

#### Motivation and Context
<!--
     Why is this change required? What problem does it solve?
     If this pull request closes/resolves an open Issue, make sure you
     include the text "fixes #xxxx", "closes #xxxx" or "resolves #xxxx" here
-->

#### How Has This Been Tested?
<!--
     Please describe in detail how you tested your changes.
     Include details of your testing environment, and the tests you ran to
     see how your change affects other areas of the code, etc.
-->

#### Additional Information (Optional)
